### PR TITLE
CI: Update actions to fix nodejs deprecation warnings.

### DIFF
--- a/.github/workflows/micropython.yml
+++ b/.github/workflows/micropython.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - name: Workspace Cache
       id: cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{runner.workspace}}
         key: workspace-micropython-${{env.MICROPYTHON_VERSION}}-${{env.WORKFLOW_VERSION}}
@@ -28,7 +28,7 @@ jobs:
     # Check out MicroPython
     - name: Checkout MicroPython
       if: steps.cache.outputs.cache-hit != 'true'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: pimoroni/micropython
         ref: ${{env.MICROPYTHON_VERSION}}
@@ -75,7 +75,7 @@ jobs:
 
     steps:
     - name: Compiler Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: /home/runner/.ccache
         key: ccache-micropython-${{matrix.shortname}}-${{github.ref}}-${{github.sha}}
@@ -84,20 +84,20 @@ jobs:
           ccache-micropython-${{matrix.shortname}}-
 
     - name: Workspace Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{runner.workspace}}
         key: workspace-micropython-${{env.MICROPYTHON_VERSION}}-${{env.WORKFLOW_VERSION}}
         restore-keys: |
           workspace-micropython-${{env.MICROPYTHON_VERSION}}-${{env.WORKFLOW_VERSION}}
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
         path: yukon
 
     # Check out Pimoroni Pico
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: pimoroni/pimoroni-pico
         ref: ${{env.PIMORONI_PICO_VERSION}}
@@ -105,7 +105,7 @@ jobs:
         path: pimoroni-pico
 
     # Check out dir2u2f
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: gadgetoid/dir2uf2
         ref: v0.0.1
@@ -162,13 +162,13 @@ jobs:
         ./dir2uf2/dir2uf2 --verbose --fs-start ${{matrix.dir2uf2_fs_start}} --fs-size ${{matrix.dir2uf2_fs_size}} --append-to micropython/ports/rp2/build/${{env.RELEASE_FILE}}.uf2 --manifest ${{env.BOARD_DIR}}/uf2-manifest.txt --filename ${{env.FILESYSTEM_SUFFIX}}.uf2 ${{env.FILESYSTEM_DIR}}/
 
     - name: Store .uf2 as artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{env.RELEASE_FILE}}
         path: micropython/ports/rp2/build/${{env.RELEASE_FILE}}.uf2
 
     - name: Store .uf2 + Filesystem as artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{env.RELEASE_FILE}}-${{env.FILESYSTEM_SUFFIX}}
         path: ${{env.RELEASE_FILE}}-${{env.FILESYSTEM_SUFFIX}}.uf2

--- a/.github/workflows/python-linting.yml
+++ b/.github/workflows/python-linting.yml
@@ -9,7 +9,7 @@ jobs:
     name: Python Linting
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install Python Deps
       run: python3 -m pip install ruff


### PR DESCRIPTION
Details here - https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

I think we're officially in Spring 2024, so these bumps are a little overdue.